### PR TITLE
update wag.mk

### DIFF
--- a/wag.mk
+++ b/wag.mk
@@ -1,10 +1,10 @@
 # This is the default Clever Wag Makefile.
 # Please do not alter this file directly.
-WAG_MK_VERSION := 0.4.0
+WAG_MK_VERSION := 0.4.2
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 WAG_INSTALLED := $(shell [[ -e "bin/wag" ]] && bin/wag --version)
-WAG_LATEST = $(shell curl -s https://api.github.com/repos/Clever/wag/releases/latest | grep tag_name | cut -d\" -f4)
+WAG_LATEST = $(shell curl --retry 5 -f -s https://api.github.com/repos/Clever/wag/releases/latest | grep tag_name | cut -d\" -f4)
 
 .PHONY: bin/wag wag-update-makefile wag-generate-deps ensure-wag-version-set
 
@@ -19,11 +19,11 @@ bin/wag: ensure-wag-version-set
 	$(eval WAG_VERSION := $(if $(filter latest,$(WAG_VERSION)),$(WAG_LATEST),$(WAG_VERSION)))
 	@echo "Checking for wag updates..."
 	@echo "Using wag version $(WAG_VERSION)"
-	@[[ "$(WAG_VERSION)" != "$(WAG_INSTALLED)" ]] && echo "Updating wag..." && curl -sL https://github.com/Clever/wag/releases/download/$(WAG_VERSION)/wag-$(WAG_VERSION)-$(SYSTEM)-amd64.tar.gz | tar -xz -C bin || true
+	@[[ "$(WAG_VERSION)" != "$(WAG_INSTALLED)" ]] && echo "Updating wag..." && curl --retry 5 -f -sL https://github.com/Clever/wag/releases/download/$(WAG_VERSION)/wag-$(WAG_VERSION)-$(SYSTEM)-amd64.tar.gz | tar -xz -C bin || true
 
 jsdoc2md:
 	hash npm 2>/dev/null || (echo "Could not run npm, please install node" && false)
-	test -f ./node_modules/.bin/jsdoc2md || npm install jsdoc-to-markdown@^2.0.0
+	test -f ./node_modules/.bin/jsdoc2md || npm install jsdoc-to-markdown@^4.0.0
 
 # wag-generate-deps installs all dependencies needed for wag generate.
 wag-generate-deps: bin/wag jsdoc2md


### PR DESCRIPTION
update to wag.mk so `make generate` will not error when generating markdown when using the latest wag. 
see https://clever.slack.com/archives/C0V027U9J/p1595633004103700 for context
