### PR TITLE
Bugfix events failover

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+gen-*/** linguist-generated

--- a/client_test.go
+++ b/client_test.go
@@ -88,7 +88,7 @@ func TestRestartPrimaries(t *testing.T) {
 
 	client := conf.Client()
 
-	_, err := client.RestartPrimaries(context.Background(), &models.RestartPrimariesInput{
+	err := client.RestartPrimaries(context.Background(), &models.RestartPrimariesInput{
 		GroupID:     groupID,
 		ClusterName: clusterName,
 	})

--- a/gen-go/client/client.go
+++ b/gen-go/client/client.go
@@ -23,7 +23,7 @@ var _ = strconv.FormatInt
 var _ = bytes.Compare
 
 // Version of the client.
-const Version = "0.7.0"
+const Version = "0.7.1"
 
 // VersionHeader is sent with every request.
 const VersionHeader = "X-Client-Version"
@@ -907,7 +907,7 @@ func (c *WagClient) doUpdateClusterRequest(ctx context.Context, req *http.Reques
 
 // RestartPrimaries makes a POST request to /groups/{groupID}/clusters/{clusterName}/restartPrimaries
 // Restart the cluster's primaries, triggering a failover.
-// 200: *models.RestoreJob
+// 200: nil
 // 400: *models.BadRequest
 // 401: *models.Unauthorized
 // 403: *models.Forbidden
@@ -916,14 +916,14 @@ func (c *WagClient) doUpdateClusterRequest(ctx context.Context, req *http.Reques
 // 429: *models.TooManyRequests
 // 500: *models.InternalError
 // default: client side HTTP errors, for example: context.DeadlineExceeded.
-func (c *WagClient) RestartPrimaries(ctx context.Context, i *models.RestartPrimariesInput) (*models.RestoreJob, error) {
+func (c *WagClient) RestartPrimaries(ctx context.Context, i *models.RestartPrimariesInput) error {
 	headers := make(map[string]string)
 
 	var body []byte
 	path, err := i.Path()
 
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	path = c.basePath + path
@@ -931,13 +931,13 @@ func (c *WagClient) RestartPrimaries(ctx context.Context, i *models.RestartPrima
 	req, err := http.NewRequestWithContext(ctx, "POST", path, bytes.NewBuffer(body))
 
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	return c.doRestartPrimariesRequest(ctx, req, headers)
 }
 
-func (c *WagClient) doRestartPrimariesRequest(ctx context.Context, req *http.Request, headers map[string]string) (*models.RestoreJob, error) {
+func (c *WagClient) doRestartPrimariesRequest(ctx context.Context, req *http.Request, headers map[string]string) error {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Canonical-Resource", "restartPrimaries")
 	req.Header.Set(VersionHeader, Version)
@@ -977,78 +977,73 @@ func (c *WagClient) doRestartPrimariesRequest(ctx context.Context, req *http.Req
 	if err != nil {
 		logData["message"] = err.Error()
 		c.logger.ErrorD("client-request-finished", logData)
-		return nil, err
+		return err
 	}
 	defer resp.Body.Close()
 	switch resp.StatusCode {
 
 	case 200:
 
-		var output models.RestoreJob
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return nil, err
-		}
-
-		return &output, nil
+		return nil
 
 	case 400:
 
 		var output models.BadRequest
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return nil, err
+			return err
 		}
-		return nil, &output
+		return &output
 
 	case 401:
 
 		var output models.Unauthorized
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return nil, err
+			return err
 		}
-		return nil, &output
+		return &output
 
 	case 403:
 
 		var output models.Forbidden
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return nil, err
+			return err
 		}
-		return nil, &output
+		return &output
 
 	case 404:
 
 		var output models.NotFound
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return nil, err
+			return err
 		}
-		return nil, &output
+		return &output
 
 	case 409:
 
 		var output models.Conflict
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return nil, err
+			return err
 		}
-		return nil, &output
+		return &output
 
 	case 429:
 
 		var output models.TooManyRequests
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return nil, err
+			return err
 		}
-		return nil, &output
+		return &output
 
 	case 500:
 
 		var output models.InternalError
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return nil, err
+			return err
 		}
-		return nil, &output
+		return &output
 
 	default:
-		return nil, &models.InternalError{Message: "Unknown response"}
+		return &models.InternalError{Message: "Unknown response"}
 	}
 }
 

--- a/gen-go/client/interface.go
+++ b/gen-go/client/interface.go
@@ -78,7 +78,7 @@ type Client interface {
 
 	// RestartPrimaries makes a POST request to /groups/{groupID}/clusters/{clusterName}/restartPrimaries
 	// Restart the cluster's primaries, triggering a failover.
-	// 200: *models.RestoreJob
+	// 200: nil
 	// 400: *models.BadRequest
 	// 401: *models.Unauthorized
 	// 403: *models.Forbidden
@@ -87,7 +87,7 @@ type Client interface {
 	// 429: *models.TooManyRequests
 	// 500: *models.InternalError
 	// default: client side HTTP errors, for example: context.DeadlineExceeded.
-	RestartPrimaries(ctx context.Context, i *models.RestartPrimariesInput) (*models.RestoreJob, error)
+	RestartPrimaries(ctx context.Context, i *models.RestartPrimariesInput) error
 
 	// GetRestoreJobs makes a GET request to /groups/{groupID}/clusters/{clusterName}/restoreJobs
 	// Get all restore jobs for a cluster

--- a/gen-go/models/inputs.go
+++ b/gen-go/models/inputs.go
@@ -854,8 +854,8 @@ type GetEventsInput struct {
 	ItemsPerPage *int64
 	Pretty       *bool
 	EventType    *string
-	MinDate      *strfmt.Date
-	MaxDate      *strfmt.Date
+	MinDate      *strfmt.DateTime
+	MaxDate      *strfmt.DateTime
 }
 
 // Validate returns an error if any of the GetEventsInput parameters don't satisfy the
@@ -875,13 +875,13 @@ func (i GetEventsInput) Validate() error {
 	}
 
 	if i.MinDate != nil {
-		if err := validate.FormatOf("minDate", "query", "date", (*i.MinDate).String(), strfmt.Default); err != nil {
+		if err := validate.FormatOf("minDate", "query", "date-time", (*i.MinDate).String(), strfmt.Default); err != nil {
 			return err
 		}
 	}
 
 	if i.MaxDate != nil {
-		if err := validate.FormatOf("maxDate", "query", "date", (*i.MaxDate).String(), strfmt.Default); err != nil {
+		if err := validate.FormatOf("maxDate", "query", "date-time", (*i.MaxDate).String(), strfmt.Default); err != nil {
 			return err
 		}
 	}

--- a/gen-js/README.md
+++ b/gen-js/README.md
@@ -224,7 +224,7 @@ Update a Cluster
 Restart the cluster's primaries, triggering a failover.
 
 **Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
-**Fulfill**: <code>Object</code>  
+**Fulfill**: <code>undefined</code>  
 **Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
 **Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
 **Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  

--- a/gen-js/index.d.ts
+++ b/gen-js/index.d.ts
@@ -68,7 +68,7 @@ declare class AtlasAPIClient {
   
   updateCluster(params: models.UpdateClusterParams, options?: RequestOptions, cb?: Callback<models.Cluster>): Promise<models.Cluster>
   
-  restartPrimaries(params: models.RestartPrimariesParams, options?: RequestOptions, cb?: Callback<models.RestoreJob>): Promise<models.RestoreJob>
+  restartPrimaries(params: models.RestartPrimariesParams, options?: RequestOptions, cb?: Callback<void>): Promise<void>
   
   getRestoreJobs(params: models.GetRestoreJobsParams, options?: RequestOptions, cb?: Callback<models.GetRestoreJobsResponse>): Promise<models.GetRestoreJobsResponse>
   

--- a/gen-js/index.js
+++ b/gen-js/index.js
@@ -1044,7 +1044,7 @@ class AtlasAPIClient {
    * @param {module:atlas-api-client.RetryPolicies} [options.retryPolicy] - A request specific retryPolicy
    * @param {function} [cb]
    * @returns {Promise}
-   * @fulfill {Object}
+   * @fulfill {undefined}
    * @reject {module:atlas-api-client.Errors.BadRequest}
    * @reject {module:atlas-api-client.Errors.Unauthorized}
    * @reject {module:atlas-api-client.Errors.Forbidden}
@@ -1134,7 +1134,7 @@ class AtlasAPIClient {
 
           switch (response.statusCode) {
             case 200:
-              resolve(body);
+              resolve();
               break;
 
             case 400:
@@ -5424,7 +5424,7 @@ module.exports.Errors = Errors;
 
 module.exports.DefaultCircuitOptions = defaultCircuitOptions;
 
-const version = "0.7.0";
+const version = "0.7.1";
 const versionHeader = "X-Client-Version";
 module.exports.Version = version;
 module.exports.VersionHeader = versionHeader;

--- a/gen-js/package.json
+++ b/gen-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atlas-api-client",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Swagger description of the MongoDB Atlas API: https://docs.atlas.mongodb.com/reference/api-resources/. Used to generate client code to interact with the API.",
   "main": "index.js",
   "dependencies": {

--- a/swagger.yml
+++ b/swagger.yml
@@ -2,7 +2,7 @@ swagger: '2.0'
 info:
   title: atlas-api-client
   description: "Swagger description of the MongoDB Atlas API: https://docs.atlas.mongodb.com/reference/api-resources/. Used to generate client code to interact with the API."
-  version: 0.7.0
+  version: 0.7.1
   x-npm-package: atlas-api-client
 basePath: /api/atlas/v1.0
 schemes:
@@ -460,11 +460,8 @@ paths:
           required: true
           type: string
       responses:
-        # TODO not sure if this is 200, 201, 202
         200:
           description: "Success"
-          schema:
-            $ref: "#/definitions/RestoreJob"
         401:
           description: "Unauthorized"
           schema:
@@ -1321,11 +1318,11 @@ paths:
         - name: minDate
           in: query
           type: string
-          format: date
+          format: date-time
         - name: maxDate
           in: query
           type: string
-          format: date
+          format: date-time
       responses:
         200:
           description: "Success"


### PR DESCRIPTION
Fix: Mongo docs called the parameter `date`, but they actually meant `date-time`
Fix: `RestartPrimaries` doesn't actually return anything, I messed up on a copy-paste fail.

I tested the `getEvents` change by passing a `time.Now()` and `time.Now().Add(-5*time.Hour)` in the test for it.

- [X] Update swagger.yml version
- [X] Run "make generate"
