### PR TITLE
Adding template checkbox for new EWI-6 code review standards

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,12 @@
+# Clever Coding Standards Agreement
+
+- [ ] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"
+
+# Checklist
+
 - [ ] Update swagger.yml version
 - [ ] Run "make generate"
+
+# Testing
+
+(how did you test this)


### PR DESCRIPTION
## Clever Coding Standards Agreement

- [ ] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"

## JIRA
[Link to JIRA](https://clever.atlassian.net/browse/INFRANG-7181)

## Overview

As a part of EWI-6, this PR introduces a new checkbox to the PULL\_REQUEST\_TEMPLATE.md across all repositories. This change is intended to help engineers remember that PR submissions and reviews must adhere to Clever's established coding standards.

We add a new heading: "Clever Coding Standards Agreement". This new section includes a checkbox with the following statement:

* \[ \] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"

If a pull request template already exists, the microplane script used Claude to also:

* Ensure appropriate headings are in place in the PR template.  
* Add a "Testing" section if one is not already present.  
* Inject the "Clever Coding Standards Agreement" at the beginning of the file.

If no pull request template existed, the microplane script added one.

## Testing

I ran Microplane on a subset of repos and manually verified for each repo that the changes were as intended.

## Rollout

None besides PR approval and merge.

## Rollback

None except rolling back the PR.