### PR TITLE
bump wag.mk to latest and make generate

### DIFF
--- a/gen-js/README.md
+++ b/gen-js/README.md
@@ -75,7 +75,7 @@ Create a new client object.
 | [options.discovery] | <code>bool</code> |  | Use clever-discovery to locate the server. Must provide this or the address argument |
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
 | [options.keepalive] | <code>bool</code> |  | Set keepalive to true for client requests. This sets the forever: true attribute in request. Defaults to true. |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 | [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;atlas-api-client-wagclient&quot;)</code> | The Kayvee logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |
 | [options.circuit.forceClosed] | <code>bool</code> |  | When set to true the circuit will always be closed. Default: true. |
@@ -89,15 +89,15 @@ Create a new client object.
 #### atlasAPIClient.getClusters(groupID, [options], [cb]) ⇒ <code>Promise</code>
 Get all clusters
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -105,8 +105,8 @@ Get all clusters
 | groupID | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+createCluster"></a>
@@ -114,15 +114,15 @@ Get all clusters
 #### atlasAPIClient.createCluster(params, [options], [cb]) ⇒ <code>Promise</code>
 Create a Cluster
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -132,8 +132,8 @@ Create a Cluster
 | params.createOrUpdateClusterRequest |  |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+deleteCluster"></a>
@@ -141,15 +141,15 @@ Create a Cluster
 #### atlasAPIClient.deleteCluster(params, [options], [cb]) ⇒ <code>Promise</code>
 Deletes a cluster
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>undefined</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -159,8 +159,8 @@ Deletes a cluster
 | params.clusterName | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getCluster"></a>
@@ -168,15 +168,15 @@ Deletes a cluster
 #### atlasAPIClient.getCluster(params, [options], [cb]) ⇒ <code>Promise</code>
 Gets a cluster
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -186,8 +186,8 @@ Gets a cluster
 | params.clusterName | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+updateCluster"></a>
@@ -195,15 +195,15 @@ Gets a cluster
 #### atlasAPIClient.updateCluster(params, [options], [cb]) ⇒ <code>Promise</code>
 Update a Cluster
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -214,8 +214,8 @@ Update a Cluster
 | params.createOrUpdateClusterRequest |  |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+restartPrimaries"></a>
@@ -223,15 +223,15 @@ Update a Cluster
 #### atlasAPIClient.restartPrimaries(params, [options], [cb]) ⇒ <code>Promise</code>
 Restart the cluster's primaries, triggering a failover.
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>undefined</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -241,8 +241,8 @@ Restart the cluster's primaries, triggering a failover.
 | params.clusterName | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getRestoreJobs"></a>
@@ -250,15 +250,15 @@ Restart the cluster's primaries, triggering a failover.
 #### atlasAPIClient.getRestoreJobs(params, [options], [cb]) ⇒ <code>Promise</code>
 Get all restore jobs for a cluster
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -270,8 +270,8 @@ Get all restore jobs for a cluster
 | [params.itemsPerPage] | <code>number</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+createRestoreJob"></a>
@@ -279,15 +279,15 @@ Get all restore jobs for a cluster
 #### atlasAPIClient.createRestoreJob(params, [options], [cb]) ⇒ <code>Promise</code>
 Create a restore job
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -298,8 +298,8 @@ Create a restore job
 | params.createRestoreJobRequest |  |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getSnapshotSchedule"></a>
@@ -307,11 +307,11 @@ Create a restore job
 #### atlasAPIClient.getSnapshotSchedule(params, [options], [cb]) ⇒ <code>Promise</code>
 Get snapshot schedules of a cluster
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -321,8 +321,8 @@ Get snapshot schedules of a cluster
 | params.clusterName | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+updateSnapshotSchedule"></a>
@@ -330,15 +330,15 @@ Get snapshot schedules of a cluster
 #### atlasAPIClient.updateSnapshotSchedule(params, [options], [cb]) ⇒ <code>Promise</code>
 Update a Cluster's snapshot schedule
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -349,8 +349,8 @@ Update a Cluster's snapshot schedule
 | params.updateSnapshotSchedule |  |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getSnapshots"></a>
@@ -358,12 +358,12 @@ Update a Cluster's snapshot schedule
 #### atlasAPIClient.getSnapshots(params, [options], [cb]) ⇒ <code>Promise</code>
 Gets snapshots for a cluster
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -373,8 +373,8 @@ Gets snapshots for a cluster
 | params.clusterName | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getRestoreJob"></a>
@@ -382,15 +382,15 @@ Gets snapshots for a cluster
 #### atlasAPIClient.getRestoreJob(params, [options], [cb]) ⇒ <code>Promise</code>
 Get one restore job
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -401,8 +401,8 @@ Get one restore job
 | params.jobID | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getContainers"></a>
@@ -410,15 +410,15 @@ Get one restore job
 #### atlasAPIClient.getContainers(groupID, [options], [cb]) ⇒ <code>Promise</code>
 Get All Containers
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -426,8 +426,8 @@ Get All Containers
 | groupID | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+createContainer"></a>
@@ -435,15 +435,15 @@ Get All Containers
 #### atlasAPIClient.createContainer(params, [options], [cb]) ⇒ <code>Promise</code>
 Create a Container
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -453,8 +453,8 @@ Create a Container
 | params.createOrUpdateContainerRequest |  |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getContainer"></a>
@@ -462,12 +462,12 @@ Create a Container
 #### atlasAPIClient.getContainer(params, [options], [cb]) ⇒ <code>Promise</code>
 Gets a container
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -477,8 +477,8 @@ Gets a container
 | params.containerID | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+updateContainer"></a>
@@ -486,15 +486,15 @@ Gets a container
 #### atlasAPIClient.updateContainer(params, [options], [cb]) ⇒ <code>Promise</code>
 Update a Container
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -505,8 +505,8 @@ Update a Container
 | params.createOrUpdateContainerRequest |  |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getDatabaseUsers"></a>
@@ -514,15 +514,15 @@ Update a Container
 #### atlasAPIClient.getDatabaseUsers(groupID, [options], [cb]) ⇒ <code>Promise</code>
 Get All DatabaseUsers
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -530,8 +530,8 @@ Get All DatabaseUsers
 | groupID | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+createDatabaseUser"></a>
@@ -539,15 +539,15 @@ Get All DatabaseUsers
 #### atlasAPIClient.createDatabaseUser(params, [options], [cb]) ⇒ <code>Promise</code>
 Create a DatabaseUser
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -557,8 +557,8 @@ Create a DatabaseUser
 | params.createDatabaseUserRequest |  |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+deleteDatabaseUser"></a>
@@ -566,15 +566,15 @@ Create a DatabaseUser
 #### atlasAPIClient.deleteDatabaseUser(params, [options], [cb]) ⇒ <code>Promise</code>
 Deletes a DatabaseUser
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>undefined</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -584,8 +584,8 @@ Deletes a DatabaseUser
 | params.username | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getDatabaseUser"></a>
@@ -593,12 +593,12 @@ Deletes a DatabaseUser
 #### atlasAPIClient.getDatabaseUser(params, [options], [cb]) ⇒ <code>Promise</code>
 Gets a database user
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -608,8 +608,8 @@ Gets a database user
 | params.username | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+updateDatabaseUser"></a>
@@ -617,15 +617,15 @@ Gets a database user
 #### atlasAPIClient.updateDatabaseUser(params, [options], [cb]) ⇒ <code>Promise</code>
 Update a DatabaseUser
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -636,8 +636,8 @@ Update a DatabaseUser
 | params.updateDatabaseUserRequest |  |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getEvents"></a>
@@ -645,13 +645,13 @@ Update a DatabaseUser
 #### atlasAPIClient.getEvents(params, [options], [cb]) ⇒ <code>Promise</code>
 Get Atlas events for the given group.
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -666,8 +666,8 @@ Get Atlas events for the given group.
 | [params.maxDate] | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getPeers"></a>
@@ -675,12 +675,12 @@ Get Atlas events for the given group.
 #### atlasAPIClient.getPeers(groupID, [options], [cb]) ⇒ <code>Promise</code>
 Get All VPC Peering Connections in One Project (first page only)
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -688,8 +688,8 @@ Get All VPC Peering Connections in One Project (first page only)
 | groupID | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+createPeer"></a>
@@ -697,12 +697,12 @@ Get All VPC Peering Connections in One Project (first page only)
 #### atlasAPIClient.createPeer(params, [options], [cb]) ⇒ <code>Promise</code>
 Create One New VPC Peering Connection
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -712,8 +712,8 @@ Create One New VPC Peering Connection
 | params.createPeerRequest |  |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+deletePeer"></a>
@@ -721,12 +721,12 @@ Create One New VPC Peering Connection
 #### atlasAPIClient.deletePeer(params, [options], [cb]) ⇒ <code>Promise</code>
 Delete One Existing VPC Peering Connection
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>undefined</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -736,8 +736,8 @@ Delete One Existing VPC Peering Connection
 | params.peerID | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getPeer"></a>
@@ -745,11 +745,11 @@ Delete One Existing VPC Peering Connection
 #### atlasAPIClient.getPeer(params, [options], [cb]) ⇒ <code>Promise</code>
 Gets One Specific VPC Peering Connection
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -759,8 +759,8 @@ Gets One Specific VPC Peering Connection
 | params.peerID | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+updatePeer"></a>
@@ -768,12 +768,12 @@ Gets One Specific VPC Peering Connection
 #### atlasAPIClient.updatePeer(params, [options], [cb]) ⇒ <code>Promise</code>
 Update One Existing VPC Peering Connection
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -784,8 +784,8 @@ Update One Existing VPC Peering Connection
 | params.updatePeerRequest |  |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getProcesses"></a>
@@ -793,15 +793,15 @@ Update One Existing VPC Peering Connection
 #### atlasAPIClient.getProcesses(groupID, [options], [cb]) ⇒ <code>Promise</code>
 Get All Processes
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -809,8 +809,8 @@ Get All Processes
 | groupID | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getProcessDatabases"></a>
@@ -818,15 +818,15 @@ Get All Processes
 #### atlasAPIClient.getProcessDatabases(params, [options], [cb]) ⇒ <code>Promise</code>
 Get the available databases for a Atlas MongoDB Process
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -839,8 +839,8 @@ Get the available databases for a Atlas MongoDB Process
 | [params.itemsPerPage] | <code>number</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getProcessDatabaseMeasurements"></a>
@@ -848,15 +848,15 @@ Get the available databases for a Atlas MongoDB Process
 #### atlasAPIClient.getProcessDatabaseMeasurements(params, [options], [cb]) ⇒ <code>Promise</code>
 Get the measurements of the specified database for a Atlas MongoDB process.
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -870,13 +870,13 @@ Get the measurements of the specified database for a Atlas MongoDB process.
 | [params.period] | <code>string</code> |  |
 | [params.start] | <code>string</code> |  |
 | [params.end] | <code>string</code> |  |
-| [params.m] | <code>[ &#x27;Array&#x27; ].&lt;string&gt;</code> |  |
+| [params.m] | <code>Array.&lt;string&gt;</code> |  |
 | [params.pageNum] | <code>number</code> |  |
 | [params.itemsPerPage] | <code>number</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getProcessDisks"></a>
@@ -884,15 +884,15 @@ Get the measurements of the specified database for a Atlas MongoDB process.
 #### atlasAPIClient.getProcessDisks(params, [options], [cb]) ⇒ <code>Promise</code>
 Get the available disks for a Atlas MongoDB Process
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -905,8 +905,8 @@ Get the available disks for a Atlas MongoDB Process
 | [params.itemsPerPage] | <code>number</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getProcessDiskMeasurements"></a>
@@ -914,15 +914,15 @@ Get the available disks for a Atlas MongoDB Process
 #### atlasAPIClient.getProcessDiskMeasurements(params, [options], [cb]) ⇒ <code>Promise</code>
 Get the measurements of the specified disk for a Atlas MongoDB process.
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -936,13 +936,13 @@ Get the measurements of the specified disk for a Atlas MongoDB process.
 | [params.period] | <code>string</code> |  |
 | [params.start] | <code>string</code> |  |
 | [params.end] | <code>string</code> |  |
-| [params.m] | <code>[ &#x27;Array&#x27; ].&lt;string&gt;</code> |  |
+| [params.m] | <code>Array.&lt;string&gt;</code> |  |
 | [params.pageNum] | <code>number</code> |  |
 | [params.itemsPerPage] | <code>number</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient+getProcessMeasurements"></a>
@@ -950,15 +950,15 @@ Get the measurements of the specified disk for a Atlas MongoDB process.
 #### atlasAPIClient.getProcessMeasurements(params, [options], [cb]) ⇒ <code>Promise</code>
 Get measurements for a specific Atlas MongoDB process (mongod or mongos).
 
-**Kind**: instance method of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: instance method of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 **Fulfill**: <code>Object</code>  
-**Reject**: <code>[BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)</code>  
-**Reject**: <code>[Unauthorized](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)</code>  
-**Reject**: <code>[Forbidden](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)</code>  
-**Reject**: <code>[NotFound](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)</code>  
-**Reject**: <code>[Conflict](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)</code>  
-**Reject**: <code>[TooManyRequests](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)</code>  
-**Reject**: <code>[InternalError](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)</code>  
+**Reject**: [<code>BadRequest</code>](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest)  
+**Reject**: [<code>Unauthorized</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Unauthorized)  
+**Reject**: [<code>Forbidden</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Forbidden)  
+**Reject**: [<code>NotFound</code>](#module_atlas-api-client--AtlasAPIClient.Errors.NotFound)  
+**Reject**: [<code>Conflict</code>](#module_atlas-api-client--AtlasAPIClient.Errors.Conflict)  
+**Reject**: [<code>TooManyRequests</code>](#module_atlas-api-client--AtlasAPIClient.Errors.TooManyRequests)  
+**Reject**: [<code>InternalError</code>](#module_atlas-api-client--AtlasAPIClient.Errors.InternalError)  
 **Reject**: <code>Error</code>  
 
 | Param | Type | Description |
@@ -971,13 +971,13 @@ Get measurements for a specific Atlas MongoDB process (mongod or mongos).
 | [params.period] | <code>string</code> |  |
 | [params.start] | <code>string</code> |  |
 | [params.end] | <code>string</code> |  |
-| [params.m] | <code>[ &#x27;Array&#x27; ].&lt;string&gt;</code> |  |
+| [params.m] | <code>Array.&lt;string&gt;</code> |  |
 | [params.pageNum] | <code>number</code> |  |
 | [params.itemsPerPage] | <code>number</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |
-| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
-| [options.retryPolicy] | <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code> | A request specific retryPolicy |
+| [options.span] | [<code>Span</code>](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html) | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies) | A request specific retryPolicy |
 | [cb] | <code>function</code> |  |
 
 <a name="module_atlas-api-client--AtlasAPIClient.RetryPolicies"></a>
@@ -985,7 +985,7 @@ Get measurements for a specific Atlas MongoDB process (mongod or mongos).
 #### AtlasAPIClient.RetryPolicies
 Retry policies available to use.
 
-**Kind**: static property of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: static property of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 
 * [.RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)
     * [.Exponential](#module_atlas-api-client--AtlasAPIClient.RetryPolicies.Exponential)
@@ -997,25 +997,25 @@ Retry policies available to use.
 ##### RetryPolicies.Exponential
 The exponential retry policy will retry five times with an exponential backoff.
 
-**Kind**: static constant of <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code>  
+**Kind**: static constant of [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)  
 <a name="module_atlas-api-client--AtlasAPIClient.RetryPolicies.Single"></a>
 
 ##### RetryPolicies.Single
 Use this retry policy to retry a request once.
 
-**Kind**: static constant of <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code>  
+**Kind**: static constant of [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)  
 <a name="module_atlas-api-client--AtlasAPIClient.RetryPolicies.None"></a>
 
 ##### RetryPolicies.None
 Use this retry policy to turn off retries.
 
-**Kind**: static constant of <code>[RetryPolicies](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)</code>  
+**Kind**: static constant of [<code>RetryPolicies</code>](#module_atlas-api-client--AtlasAPIClient.RetryPolicies)  
 <a name="module_atlas-api-client--AtlasAPIClient.Errors"></a>
 
 #### AtlasAPIClient.Errors
 Errors returned by methods.
 
-**Kind**: static property of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: static property of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  
 
 * [.Errors](#module_atlas-api-client--AtlasAPIClient.Errors)
     * [.BadRequest](#module_atlas-api-client--AtlasAPIClient.Errors.BadRequest) ⇐ <code>Error</code>
@@ -1031,8 +1031,8 @@ Errors returned by methods.
 ##### Errors.BadRequest ⇐ <code>Error</code>
 BadRequest
 
-**Kind**: static class of <code>[Errors](#module_atlas-api-client--AtlasAPIClient.Errors)</code>  
-**Extends:** <code>Error</code>  
+**Kind**: static class of [<code>Errors</code>](#module_atlas-api-client--AtlasAPIClient.Errors)  
+**Extends**: <code>Error</code>  
 **Properties**
 
 | Name | Type |
@@ -1047,8 +1047,8 @@ BadRequest
 ##### Errors.Unauthorized ⇐ <code>Error</code>
 Unauthorized
 
-**Kind**: static class of <code>[Errors](#module_atlas-api-client--AtlasAPIClient.Errors)</code>  
-**Extends:** <code>Error</code>  
+**Kind**: static class of [<code>Errors</code>](#module_atlas-api-client--AtlasAPIClient.Errors)  
+**Extends**: <code>Error</code>  
 **Properties**
 
 | Name | Type |
@@ -1063,8 +1063,8 @@ Unauthorized
 ##### Errors.Forbidden ⇐ <code>Error</code>
 Forbidden
 
-**Kind**: static class of <code>[Errors](#module_atlas-api-client--AtlasAPIClient.Errors)</code>  
-**Extends:** <code>Error</code>  
+**Kind**: static class of [<code>Errors</code>](#module_atlas-api-client--AtlasAPIClient.Errors)  
+**Extends**: <code>Error</code>  
 **Properties**
 
 | Name | Type |
@@ -1079,8 +1079,8 @@ Forbidden
 ##### Errors.NotFound ⇐ <code>Error</code>
 NotFound
 
-**Kind**: static class of <code>[Errors](#module_atlas-api-client--AtlasAPIClient.Errors)</code>  
-**Extends:** <code>Error</code>  
+**Kind**: static class of [<code>Errors</code>](#module_atlas-api-client--AtlasAPIClient.Errors)  
+**Extends**: <code>Error</code>  
 **Properties**
 
 | Name | Type |
@@ -1095,8 +1095,8 @@ NotFound
 ##### Errors.Conflict ⇐ <code>Error</code>
 Conflict
 
-**Kind**: static class of <code>[Errors](#module_atlas-api-client--AtlasAPIClient.Errors)</code>  
-**Extends:** <code>Error</code>  
+**Kind**: static class of [<code>Errors</code>](#module_atlas-api-client--AtlasAPIClient.Errors)  
+**Extends**: <code>Error</code>  
 **Properties**
 
 | Name | Type |
@@ -1111,8 +1111,8 @@ Conflict
 ##### Errors.TooManyRequests ⇐ <code>Error</code>
 TooManyRequests
 
-**Kind**: static class of <code>[Errors](#module_atlas-api-client--AtlasAPIClient.Errors)</code>  
-**Extends:** <code>Error</code>  
+**Kind**: static class of [<code>Errors</code>](#module_atlas-api-client--AtlasAPIClient.Errors)  
+**Extends**: <code>Error</code>  
 **Properties**
 
 | Name | Type |
@@ -1127,8 +1127,8 @@ TooManyRequests
 ##### Errors.InternalError ⇐ <code>Error</code>
 InternalError
 
-**Kind**: static class of <code>[Errors](#module_atlas-api-client--AtlasAPIClient.Errors)</code>  
-**Extends:** <code>Error</code>  
+**Kind**: static class of [<code>Errors</code>](#module_atlas-api-client--AtlasAPIClient.Errors)  
+**Extends**: <code>Error</code>  
 **Properties**
 
 | Name | Type |
@@ -1143,4 +1143,4 @@ InternalError
 #### AtlasAPIClient.DefaultCircuitOptions
 Default circuit breaker options.
 
-**Kind**: static constant of <code>[AtlasAPIClient](#exp_module_atlas-api-client--AtlasAPIClient)</code>  
+**Kind**: static constant of [<code>AtlasAPIClient</code>](#exp_module_atlas-api-client--AtlasAPIClient)  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,730 +1,997 @@
 {
+  "name": "planned",
+  "lockfileVersion": 3,
   "requires": true,
-  "lockfileVersion": 1,
-  "dependencies": {
-    "acorn": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
-    },
-    "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "requires": {
-        "acorn": "^3.0.4"
-      }
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-    },
-    "ansi-escape-sequences": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-3.0.0.tgz",
-      "integrity": "sha1-HBg5S2r5t2/5pjUJ+kl2af0s5T4=",
-      "requires": {
-        "array-back": "^1.0.3"
-      }
-    },
-    "app-usage-stats": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/app-usage-stats/-/app-usage-stats-0.4.1.tgz",
-      "integrity": "sha1-l+ubibVnj6LdyXk7EphijMIYQp8=",
-      "requires": {
-        "array-back": "^1.0.4",
-        "core-js": "^2.4.1",
-        "feature-detect-es6": "^1.3.1",
-        "home-path": "^1.0.3",
-        "test-value": "^2.1.0",
-        "usage-stats": "^0.8.2"
-      }
-    },
-    "array-back": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-      "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
-      "requires": {
-        "typical": "^2.6.0"
-      }
-    },
-    "async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-      "optional": true
-    },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
+  "packages": {
+    "": {
       "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        "jsdoc-to-markdown": "^9.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.5"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@jsdoc/salty": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.9.tgz",
+      "integrity": "sha512-yYxMVH7Dqw6nO0d5NIV8OQWnitU8k6vXH8NtgqAfIa/IUqRMxRv/NUJJ08VEKbAakwxlgBl5PJdrU0dMPStsnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v12.0.0"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/array-back": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "license": "MIT"
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cache-point": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-3.0.1.tgz",
+      "integrity": "sha512-itTIMLEKbh6Dw5DruXbxAgcyLnh/oPGVLBfTPqBOftASxHe8bAeXy7JkO4F0LvHqht7XqP5O/09h5UcHS2w0FA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12.17"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
         }
       }
     },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "bluebird": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+    "node_modules/catharsis": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
-    "cache-point": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-0.3.4.tgz",
-      "integrity": "sha1-FS21Asa7I7WqP2Y+Iw1d6OxOTz8=",
-      "requires": {
-        "array-back": "^1.0.3",
-        "core-js": "^2.4.1",
-        "feature-detect-es6": "^1.3.1",
-        "fs-then-native": "^1.0.2",
-        "mkdirp": "~0.5.1"
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "catharsis": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
-      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
-      "requires": {
-        "lodash": "^4.17.14"
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
       }
     },
-    "cli-commands": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cli-commands/-/cli-commands-0.1.0.tgz",
-      "integrity": "sha1-xXysxAa7z57iFkZgcWHtQy71oFo=",
-      "requires": {
-        "ansi-escape-sequences": "^3.0.0",
-        "command-line-args": "^3.0.1",
-        "command-line-commands": "^1.0.4",
-        "command-line-usage": "^3.0.5"
-      }
-    },
-    "collect-all": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.3.tgz",
-      "integrity": "sha512-0y0rBgoX8IzIjBAUnO73SEtSb4Mhk3IoceWJq5zZSxb9mWORhWH8xLYo4EDSOE1jRBk1LhmfjqWFFt10h/+MEA==",
-      "requires": {
-        "stream-connect": "^1.0.2",
-        "stream-via": "^1.0.4"
-      }
-    },
-    "command-line-args": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-3.0.5.tgz",
-      "integrity": "sha1-W9StReeYPlwTRJGOQCgO4mk8WsA=",
-      "requires": {
-        "array-back": "^1.0.4",
-        "feature-detect-es6": "^1.3.1",
-        "find-replace": "^1.0.2",
-        "typical": "^2.6.0"
-      }
-    },
-    "command-line-commands": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/command-line-commands/-/command-line-commands-1.0.4.tgz",
-      "integrity": "sha1-A0+bFntRiK+9z2su+7FQ/IRCwys=",
-      "requires": {
-        "array-back": "^1.0.3",
-        "feature-detect-es6": "^1.3.1"
-      }
-    },
-    "command-line-tool": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.6.4.tgz",
-      "integrity": "sha1-TBHjcvPkElSGHD/mtTjTx6WxRPM=",
-      "requires": {
-        "ansi-escape-sequences": "^3.0.0",
-        "array-back": "^1.0.3",
-        "command-line-args": "^3.0.1",
-        "command-line-usage": "^3.0.3",
-        "feature-detect-es6": "^1.3.1",
-        "typical": "^2.6.0"
-      }
-    },
-    "command-line-usage": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-3.0.8.tgz",
-      "integrity": "sha1-tqIJeMGzg0d/XBGlKUKLiAv+D00=",
-      "requires": {
-        "ansi-escape-sequences": "^3.0.0",
-        "array-back": "^1.0.3",
-        "feature-detect-es6": "^1.3.1",
-        "table-layout": "^0.3.0",
-        "typical": "^2.6.0"
-      }
-    },
-    "common-sequence": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
-      "integrity": "sha1-MOB/P49vf5s97oVPILLTnu4Ibeg="
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "config-master": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/config-master/-/config-master-2.0.4.tgz",
-      "integrity": "sha1-50lQXF0/lG8vrTx23+cfymiXUdw=",
-      "requires": {
-        "babel-polyfill": "^6.13.0",
-        "feature-detect-es6": "^1.3.1",
-        "walk-back": "^2.0.1"
-      }
-    },
-    "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
-    },
-    "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-    },
-    "defer-promise": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/defer-promise/-/defer-promise-1.0.2.tgz",
-      "integrity": "sha512-5a0iWJvnon50nLLqHPW83pX45BLb4MmlSa1sIg05NBhZoK5EZGz1s8qoZ3888dVGGOT0Ni01NdETuAgdJUZknA=="
-    },
-    "dmd": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/dmd/-/dmd-2.1.2.tgz",
-      "integrity": "sha1-dL6N5tbqeNBLEUF9bGvy8dM+xoY=",
-      "requires": {
-        "array-back": "^1.0.3",
-        "cache-point": "^0.3.4",
-        "common-sequence": "^1.0.2",
-        "core-js": "^2.4.1",
-        "file-set": "^1.1.1",
-        "handlebars": "3.0.3",
-        "marked": "^0.3.6",
-        "object-get": "^2.1.0",
-        "reduce-flatten": "^1.0.1",
-        "reduce-unique": "^1.0.0",
-        "reduce-without": "^1.0.1",
-        "test-value": "^2.1.0",
-        "walk-back": "^2.0.1"
-      }
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-    },
-    "espree": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.7.tgz",
-      "integrity": "sha1-/V3ux2qXpRIKnNOnyxF3oJI7EdI=",
-      "requires": {
-        "acorn": "^3.3.0",
-        "acorn-jsx": "^3.0.0"
-      }
-    },
-    "feature-detect-es6": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.5.0.tgz",
-      "integrity": "sha512-DzWPIGzTnfp3/KK1d/YPfmgLqeDju9F2DQYBL35VusgSApcA7XGqVtXfR4ETOOFEzdFJ3J7zh0Gkk011TiA4uQ==",
-      "requires": {
-        "array-back": "^1.0.4"
-      }
-    },
-    "file-set": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/file-set/-/file-set-1.1.2.tgz",
-      "integrity": "sha512-xDXI09w+l+mXxWDym7dQXy3PLdo7DygHlAtRnQ6XIMa0iY/qX6+1J75jjwCArCd48yCiMx2+fRn50BTFd45+jQ==",
-      "requires": {
-        "array-back": "^1.0.3",
-        "glob": "^7.1.0"
-      }
-    },
-    "find-replace": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
-      "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
-      "requires": {
-        "array-back": "^1.0.4",
-        "test-value": "^2.1.0"
-      }
-    },
-    "fs-then-native": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-1.0.2.tgz",
-      "integrity": "sha1-rI04B8nxu9Enlgf7Io4Ktkm7Qf4=",
-      "requires": {
-        "feature-detect-es6": "^1.3.1"
-      }
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "optional": true
-    },
-    "handlebars": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
-      "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
-      "requires": {
-        "optimist": "^0.6.1",
-        "source-map": "^0.1.40",
-        "uglify-js": "~2.3"
-      }
-    },
-    "home-path": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.7.tgz",
-      "integrity": "sha512-tM1pVa+u3ZqQwIkXcWfhUlY3HWS3TsnKsfi2OHHvnhkX52s9etyktPyy1rQotkr0euWimChDq+QkQuDe8ngUlQ=="
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "js2xmlparser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-1.0.0.tgz",
-      "integrity": "sha1-WhcPLo1kds5FQF4EgjJCUTeC/jA="
-    },
-    "jsdoc-75lb": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-75lb/-/jsdoc-75lb-3.6.0.tgz",
-      "integrity": "sha1-qAcRlSi0AJzLyrSbdSL2P+xs0L0=",
-      "requires": {
-        "bluebird": "~3.4.6",
-        "catharsis": "~0.8.8",
-        "escape-string-regexp": "~1.0.5",
-        "espree": "~3.1.7",
-        "js2xmlparser": "~1.0.0",
-        "klaw": "~1.3.0",
-        "marked": "~0.3.6",
-        "mkdirp": "~0.5.1",
-        "requizzle": "~0.2.1",
-        "strip-json-comments": "~2.0.1",
-        "taffydb": "2.6.2",
-        "underscore": "~1.8.3"
-      }
-    },
-    "jsdoc-api": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-2.0.6.tgz",
-      "integrity": "sha1-l4/69zvms+32l5nTWZzHaVuCumU=",
-      "requires": {
-        "array-back": "^1.0.3",
-        "cache-point": "~0.3.4",
-        "collect-all": "^1.0.2",
-        "core-js": "^2.4.1",
-        "feature-detect-es6": "^1.3.1",
-        "file-set": "^1.1.1",
-        "fs-then-native": "^1.0.2",
-        "jsdoc-75lb": "^3.6.0",
-        "object-to-spawn-args": "^1.1.0",
-        "temp-path": "^1.0.0",
-        "walk-back": "^2.0.1"
-      }
-    },
-    "jsdoc-parse": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-2.0.5.tgz",
-      "integrity": "sha1-bUFj6Gk/YFSrQd1M/GQyYJWPFHc=",
-      "requires": {
-        "array-back": "^1.0.3",
-        "core-js": "^2.4.1",
-        "feature-detect-es6": "^1.3.1",
-        "lodash.omit": "^4.5.0",
-        "lodash.pick": "^4.4.0",
-        "reduce-extract": "^1.0.0",
-        "sort-array": "^1.1.1",
-        "test-value": "^2.1.0"
-      }
-    },
-    "jsdoc-to-markdown": {
+    "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-2.0.1.tgz",
-      "integrity": "sha1-l+tNcWp3ZPdZWib80zh8hct6uiU=",
-      "requires": {
-        "array-back": "^1.0.3",
-        "command-line-tool": "^0.6.4",
-        "config-master": "^2.0.4",
-        "core-js": "^2.4.1",
-        "dmd": "^2.1.2",
-        "feature-detect-es6": "^1.3.1",
-        "jsdoc-api": "^2.0.5",
-        "jsdoc-parse": "^2.0.5",
-        "jsdoc2md-stats": "^1.0.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/command-line-args": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.1.tgz",
+      "integrity": "sha512-Jr3eByUjqyK0qd8W0SGFW1nZwqCaNCtbXjRo2cRJC1OYxWl3MZ5t1US3jq+cO4sPavqgw4l9BMGX0CBe+trepg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.2.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.3.tgz",
+      "integrity": "sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.0",
+        "typical": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/common-sequence": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-3.0.0.tgz",
+      "integrity": "sha512-g/CgSYk93y+a1IKm50tKl7kaT/OjjTYVQlEbUlt/49ZLV1mcKpUU7iyDiqTAeLdb4QDtQfq3ako8y8v//fzrWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/config-master": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/config-master/-/config-master-3.1.0.tgz",
+      "integrity": "sha512-n7LBL1zBzYdTpF1mx5DNcZnZn05CWIdsdvtPL4MosvqbBUK3Rq6VWEtGUuF3Y0s9/CIhMejezqlSkP6TnCJ/9g==",
+      "license": "MIT",
+      "dependencies": {
         "walk-back": "^2.0.1"
       }
     },
-    "jsdoc2md-stats": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/jsdoc2md-stats/-/jsdoc2md-stats-1.0.6.tgz",
-      "integrity": "sha1-3A4AKuu9D7rlEjU0+Scyr7xlH78=",
-      "requires": {
-        "app-usage-stats": "^0.4.0",
-        "feature-detect-es6": "^1.3.1"
+    "node_modules/config-master/node_modules/walk-back": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
+      "integrity": "sha512-Nb6GvBR8UWX1D+Le+xUq0+Q1kFmRBIWVrfLnQAOmcpEzA9oAxwJ9gIr36t9TWYfzvWRvuMtjHiVsJYEkXWaTAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "klaw": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "requires": {
+    "node_modules/current-module-paths": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/current-module-paths/-/current-module-paths-1.1.3.tgz",
+      "integrity": "sha512-7AH+ZTRKikdK4s1RmY0l6067UD/NZc7p3zZVZxvmnH80G31kr0y0W0E6ibYM4IS01MEm8DiC5FnTcgcgkbFHoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/dmd": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-7.1.1.tgz",
+      "integrity": "sha512-Ap2HP6iuOek7eShReDLr9jluNJm9RMZESlt29H/Xs1qrVMkcS9X6m5h1mBC56WMxNiSo0wvjGICmZlYUSFjwZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "cache-point": "^3.0.0",
+        "common-sequence": "^3.0.0",
+        "file-set": "^5.2.2",
+        "handlebars": "^4.7.8",
+        "marked": "^4.3.0",
+        "walk-back": "^5.1.1"
+      },
+      "engines": {
+        "node": ">=12.17"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-set": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/file-set/-/file-set-5.3.0.tgz",
+      "integrity": "sha512-FKCxdjLX0J6zqTWdT0RXIxNF/n7MyXXnsSUp0syLEOCKdexvPZ02lNNv2a+gpK9E3hzUYF3+eFZe32ci7goNUg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "fast-glob": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=12.17"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/js2xmlparser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
+    "node_modules/jsdoc": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.5.tgz",
+      "integrity": "sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/parser": "^7.20.15",
+        "@jsdoc/salty": "^0.2.1",
+        "@types/markdown-it": "^14.1.1",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.2",
+        "klaw": "^3.0.0",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^8.6.7",
+        "marked": "^4.0.10",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "underscore": "~1.13.2"
+      },
+      "bin": {
+        "jsdoc": "jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/jsdoc-api": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-9.3.5.tgz",
+      "integrity": "sha512-TQwh1jA8xtCkIbVwm/XA3vDRAa5JjydyKx1cC413Sh3WohDFxcMdwKSvn4LOsq2xWyAmOU/VnSChTQf6EF0R8g==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "cache-point": "^3.0.1",
+        "current-module-paths": "^1.1.2",
+        "file-set": "^5.3.0",
+        "jsdoc": "^4.0.4",
+        "object-to-spawn-args": "^2.0.1",
+        "walk-back": "^5.1.1"
+      },
+      "engines": {
+        "node": ">=12.17"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdoc-parse": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.2.5.tgz",
+      "integrity": "sha512-8JaSNjPLr2IuEY4Das1KM6Z4oLHZYUnjRrr27hKSa78Cj0i5Lur3DzNnCkz+DfrKBDoljGMoWOiBVQbtUZJBPw==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "find-replace": "^5.0.1",
+        "sort-array": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdoc-to-markdown": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-9.0.0.tgz",
+      "integrity": "sha512-wUgad4sac29h3uKbaqV9D49BqHXB0JvoZH3u8Jt6f4hMMcGPtA8RNwV31YJpgsZV5QFMxaT9ben9h52I6rGyUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "command-line-args": "^6.0.0",
+        "command-line-usage": "^7.0.3",
+        "config-master": "^3.1.0",
+        "dmd": "^7.0.5",
+        "jsdoc-api": "^9.3.1",
+        "jsdoc-parse": "^6.2.4",
+        "walk-back": "^5.1.1"
+      },
+      "bin": {
+        "jsdoc2md": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=12.17"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "license": "MIT",
+      "dependencies": {
         "graceful-fs": "^4.1.9"
       }
     },
-    "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
-    },
-    "lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
-    },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
-    },
-    "marked": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-    },
-    "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "requires": {
-        "minimist": "^1.2.5"
-      }
-    },
-    "mkdirp2": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.4.tgz",
-      "integrity": "sha512-Q2PKB4ZR4UPtjLl76JfzlgSCUZhSV1AXQgAZa1qt5RiaALFjP/CDrGvFBrOz7Ck6McPcwMAxTsJvWOUjOU8XMw=="
-    },
-    "object-get": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.1.tgz",
-      "integrity": "sha512-7n4IpLMzGGcLEMiQKsNR7vCe+N5E9LORFrtNUVy4sO3dj9a3HedZCxEL2T7QuLhcHN1NBuBsMOKaOsAYI9IIvg=="
-    },
-    "object-to-spawn-args": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-1.1.1.tgz",
-      "integrity": "sha1-d9qIJ/Bz0BHJ4bFz+JV4FHAkZ4U="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
       "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-        }
+        "uc.micro": "^2.0.0"
       }
     },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
-    "reduce-extract": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
-      "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
-      "requires": {
-        "test-value": "^1.0.1"
-      },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "license": "MIT",
       "dependencies": {
-        "test-value": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
-          "requires": {
-            "array-back": "^1.0.2",
-            "typical": "^2.4.2"
-          }
-        }
-      }
-    },
-    "reduce-flatten": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc="
-    },
-    "reduce-unique": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-1.0.0.tgz",
-      "integrity": "sha1-flhrz4ek4ytter2Cd/rWzeyfSAM="
-    },
-    "reduce-without": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
-      "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
-      "requires": {
-        "test-value": "^2.0.0"
-      }
-    },
-    "regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-    },
-    "req-then": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/req-then/-/req-then-0.5.1.tgz",
-      "integrity": "sha1-McbgtW9N3SrNbeC6G86ne2B5398=",
-      "requires": {
-        "array-back": "^1.0.3",
-        "defer-promise": "^1.0.0",
-        "feature-detect-es6": "^1.3.1",
-        "lodash.pick": "^4.4.0",
-        "typical": "^2.6.0"
-      }
-    },
-    "requizzle": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
-      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
-    },
-    "sort-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-1.1.2.tgz",
-      "integrity": "sha1-uImGBTwBcKf53mPxiknsecJMPmQ=",
-      "requires": {
-        "array-back": "^1.0.4",
-        "object-get": "^2.1.0",
-        "typical": "^2.6.0"
-      }
-    },
-    "source-map": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-      "requires": {
-        "amdefine": ">=0.0.4"
-      }
-    },
-    "stream-connect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-      "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
-      "requires": {
-        "array-back": "^1.0.2"
-      }
-    },
-    "stream-via": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
-      "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ=="
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-    },
-    "table-layout": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.3.0.tgz",
-      "integrity": "sha1-buINxIPbNxs+XIf3BO0vfHmdLJo=",
-      "requires": {
-        "array-back": "^1.0.3",
-        "core-js": "^2.4.1",
-        "deep-extend": "~0.4.1",
-        "feature-detect-es6": "^1.3.1",
-        "typical": "^2.6.0",
-        "wordwrapjs": "^2.0.0-0"
-      }
-    },
-    "taffydb": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg="
-    },
-    "temp-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
-      "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs="
-    },
-    "test-value": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-      "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
-      "requires": {
-        "array-back": "^1.0.3",
-        "typical": "^2.6.0"
-      }
-    },
-    "typical": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
-    },
-    "uglify-js": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-      "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
-      "optional": true,
-      "requires": {
-        "async": "~0.2.6",
-        "optimist": "~0.3.5",
-        "source-map": "~0.1.7"
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
       },
-      "dependencies": {
-        "optimist": {
-          "version": "0.3.7",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-          "optional": true,
-          "requires": {
-            "wordwrap": "~0.0.2"
-          }
-        }
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
-    "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-    },
-    "usage-stats": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/usage-stats/-/usage-stats-0.8.6.tgz",
-      "integrity": "sha512-QS1r7a1h5g1jo6KulvVGV+eQM+Jfj87AjJBfr1iaIJYz+N7+Qh7ezaVFCulwBGd8T1EidRiSYphG17gra2y0kg==",
-      "requires": {
-        "array-back": "^1.0.4",
-        "cli-commands": "0.1.0",
-        "core-js": "^2.4.1",
-        "feature-detect-es6": "^1.3.1",
-        "home-path": "^1.0.5",
-        "mkdirp2": "^1.0.3",
-        "req-then": "0.5.1",
-        "typical": "^2.6.1",
-        "uuid": "^3.0.1"
+    "node_modules/markdown-it-anchor": {
+      "version": "8.6.7",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
       }
     },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
-    "walk-back": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
-      "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ="
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-    },
-    "wordwrapjs": {
+    "node_modules/mdurl": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-2.0.0.tgz",
-      "integrity": "sha1-q1X2leYRjak4WP3XDAU9HF4BrCA=",
-      "requires": {
-        "array-back": "^1.0.3",
-        "feature-detect-es6": "^1.3.1",
-        "reduce-flatten": "^1.0.1",
-        "typical": "^2.6.0"
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
+    },
+    "node_modules/object-to-spawn-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-2.0.1.tgz",
+      "integrity": "sha512-6FuKFQ39cOID+BMZ3QaphcC8Y4cw6LXBLyIgPU+OhIYwviJamPAn+4mITapnSBQrejB+NNp+FMskhD8Cq+Ys3w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/requizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/sort-array": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-5.1.1.tgz",
+      "integrity": "sha512-EltS7AIsNlAFIM9cayrgKrM6XP94ATWwXP4LCL4IQbvbYhELSt2hZTrixg+AaQwnWFs/JGJgqU3rxMcNNWxGAA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "typical": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12.17"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "^0.1.1"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "license": "MIT"
+    },
+    "node_modules/walk-back": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.1.1.tgz",
+      "integrity": "sha512-e/FRLDVdZQWFrAzU6Hdvpm7D7m2ina833gIKLptQykRK49mmCYHLHq7UqjPDbxbKLZkTkW1rFqbengdE3sLfdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "license": "MIT"
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/xmlcreate": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
+      "license": "Apache-2.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "jsdoc-to-markdown": "^9.0.0"
+  }
+}

--- a/wag.mk
+++ b/wag.mk
@@ -1,13 +1,18 @@
 # This is the default Clever Wag Makefile.
 # Please do not alter this file directly.
-WAG_MK_VERSION := 0.4.2
+WAG_MK_VERSION := 0.8.0
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
+ifndef CI
 WAG_INSTALLED := $(shell [[ -e "bin/wag" ]] && bin/wag --version)
 WAG_LATEST = $(shell curl --retry 5 -f -s https://api.github.com/repos/Clever/wag/releases/latest | grep tag_name | cut -d\" -f4)
+endif
+.PHONY: wag-update-makefile ensure-wag-version-set wag-generate-deps jsdoc2md
 
-.PHONY: bin/wag wag-update-makefile wag-generate-deps ensure-wag-version-set
+# identify path to jsdoc2md which makes it a file target
+VPATH = node_modules/.bin
 
+ifndef CI
 ensure-wag-version-set:
 	@ if [[ "$(WAG_VERSION)" = "" ]]; then \
 		echo "WAG_VERSION not set in Makefile - Suggest setting 'WAG_VERSION := latest'"; \
@@ -18,24 +23,75 @@ bin/wag: ensure-wag-version-set
 	@mkdir -p bin
 	$(eval WAG_VERSION := $(if $(filter latest,$(WAG_VERSION)),$(WAG_LATEST),$(WAG_VERSION)))
 	@echo "Checking for wag updates..."
-	@echo "Using wag version $(WAG_VERSION)"
-	@[[ "$(WAG_VERSION)" != "$(WAG_INSTALLED)" ]] && echo "Updating wag..." && curl --retry 5 -f -sL https://github.com/Clever/wag/releases/download/$(WAG_VERSION)/wag-$(WAG_VERSION)-$(SYSTEM)-amd64.tar.gz | tar -xz -C bin || true
+	@echo "Using wag version $(WAG_INSTALLED)"
+	@if [[ "$(WAG_VERSION)" != "$(WAG_INSTALLED)" ]]; \
+		then \
+			echo "Updating wag...to $(WAG_VERSION)"  && wget -P bin https://github.com/Clever/wag/releases/download/$(WAG_VERSION)/wag-$(WAG_VERSION)-$(SYSTEM)-amd64.tar.gz ; \
+		fi;
+	@if [ -a bin/wag-$(WAG_VERSION)-$(SYSTEM)-amd64.tar.gz ] ; \
+		then \
+			tar xvf bin/wag-$(WAG_VERSION)-$(SYSTEM)-amd64.tar.gz -C bin;\
+			rm bin/wag-$(WAG_VERSION)-$(SYSTEM)-amd64.tar.gz ; \
+		fi;
+	@[[ "$(WAG_VERSION)" != "$(WAG_INSTALLED)" ]] && touch swagger.yml || true
 
 jsdoc2md:
 	hash npm 2>/dev/null || (echo "Could not run npm, please install node" && false)
-	test -f ./node_modules/.bin/jsdoc2md || npm install jsdoc-to-markdown@^4.0.0
+	@if [ ! -f ./node_modules/.bin/jsdoc2md ]; then \
+		npm install jsdoc-to-markdown@9.0.0; \
+	elif [ -f ./node_modules/jsdoc-to-markdown/package.json ]; then \
+		INSTALLED_VERSION=$$(node -p "require('./node_modules/jsdoc-to-markdown/package.json').version" 2>/dev/null || echo ""); \
+		if [ "$$INSTALLED_VERSION" != "9.0.0" ]; then \
+			echo "jsdoc-to-markdown version $$INSTALLED_VERSION detected, updating to 9.0.0..."; \
+			npm install jsdoc-to-markdown@9.0.0; \
+		fi; \
+	fi
 
 # wag-generate-deps installs all dependencies needed for wag generate.
 wag-generate-deps: bin/wag jsdoc2md
+else
+ensure-wag-version-set:
+bin/wag:
+jsdoc2md:
+endif
+
+# wag-yaml-aliases generate code workaround to use YAML aliases in swagger.yml for modules repos
+# wag parses the file into go-yaml's MapSlice, which does not handle out of order aliases: https://github.com/go-yaml/yaml/issues/438
+# arg1: path to swagger.yml
+define wag-yaml-aliases
+@if [ -z "$$CI" ]; then \
+	cat $(1) | python3 -c "import sys, yaml, json; y=yaml.load(sys.stdin.read(), yaml.Loader); print(yaml.dump(y))" > /tmp/swagger.catapult.yml; \
+	bin/wag -output-path ./gen-go -js-path ./gen-js -file /tmp/swagger.catapult.yml; \
+	(cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md); \
+else \
+	echo "skipping wag-yaml-aliases in CI"; \
+fi;
+endef
 
 # wag-generate is a target for generating code from a swagger.yml using wag
 # arg1: path to swagger.yml
 # arg2: pkg path
 define wag-generate
-bin/wag -go-package $(2)/gen-go -js-path ./gen-js -file $(1)
-(cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md)
+@if [ -z "$$CI" ]; then \
+    bin/wag -go-package $(2)/gen-go -js-path ./gen-js -file $(1); \
+    (cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md); \
+else \
+	echo "skipping wag-generate in CI"; \
+fi;
+endef
+
+# wag-generate-mod is a target for generating code from a swagger.yml using wag for modules repos
+# arg1: path to swagger.yml
+define wag-generate-mod
+@if [ -z "$$CI" ]; then \
+    bin/wag -output-path ./gen-go -js-path ./gen-js -file $(1); \
+    (cd ./gen-js && ../node_modules/.bin/jsdoc2md index.js types.js > ./README.md); \
+else \
+    echo "skipping wag-generate-mod in CI"; \
+fi;
 endef
 
 wag-update-makefile:
 	@wget https://raw.githubusercontent.com/Clever/dev-handbook/master/make/wag.mk -O /tmp/wag.mk 2>/dev/null
 	@if ! grep -q $(WAG_MK_VERSION) /tmp/wag.mk; then cp /tmp/wag.mk wag.mk && echo "wag.mk updated"; else echo "wag.mk is up-to-date"; fi
+


### PR DESCRIPTION
# JIRA

https://clever.atlassian.net/browse/INFRANG-7023

# Overview

Updating wag.mk to [latest version](https://github.com/Clever/dev-handbook/pull/177). The current jsdoc2md version doesn't work with node 24 so this version of wag.mk updates that.

I also ran `make generate` to bump the generated code with the latest version of wag.

# Testing

I have tested this with catapult and it works. This PR is created via microplane.

# Rollout

If CI is passing feel free to approve and merge this PR. If this PR is not merged within a week, infra will merge it.
